### PR TITLE
Potential fix for code scanning alert no. 3: Exposed Spring Boot actuators in configuration file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+        <!-- Enable Spring Security to protect actuator and web endpoints -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>


### PR DESCRIPTION
Potential fix for [https://github.com/hyperpostulate/customer-api/security/code-scanning/3](https://github.com/hyperpostulate/customer-api/security/code-scanning/3)

General approach: ensure that actuator endpoints, if exposed, are protected by Spring Security. The recommended and simplest way in a Spring Boot app is to add the `spring-boot-starter-security` dependency so that actuators are secured by default.

Best concrete fix here: in `pom.xml`, add a new `<dependency>` entry for `org.springframework.boot:spring-boot-starter-security` alongside the existing actuator dependency. This does not alter any existing dependencies or functionality other than introducing authentication/authorization according to Spring Security defaults, which is precisely what is desired to mitigate insecure actuator exposure.

Specifically:
- Edit `pom.xml` in the `<dependencies>` section.
- After the existing actuator dependency block (lines 24–27), insert a new dependency block:

```xml
        <dependency>
            <groupId>org.springframework.boot</groupId>
            <artifactId>spring-boot-starter-security</artifactId>
        </dependency>
```

No additional imports or code changes are needed in Java files for this minimal fix; Spring Boot auto-configures security when this starter is on the classpath.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
