### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@
 
 name: Java CI with Maven & Docker Build
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/hyperpostulate/customer-api/security/code-scanning/5](https://github.com/hyperpostulate/customer-api/security/code-scanning/5)

In general, the fix is to add an explicit `permissions` block that grants only the scopes required by this workflow, either at the workflow root (affecting all jobs) or within the `build` job. This limits the implicit privileges of `GITHUB_TOKEN` and satisfies the CodeQL rule.

For this specific workflow, the steps are:  
- `actions/checkout` and `actions/setup-java` only need read access to repository contents.  
- `advanced-security/maven-dependency-submission-action` needs `security-events: write` to upload the dependency graph.  
- The Maven build and Docker build steps don’t interact with GitHub APIs directly.  

So the best minimal configuration is:

```yaml
permissions:
  contents: read
  security-events: write
```

Placed at the top level (alongside `name` and `on`), it will apply to all jobs. Concretely, in `.github/workflows/build.yml`, insert this `permissions` block after the `name:` definition (line 9) and before the `on:` block (line 11). No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
