### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/hyperpostulate/customer-api/security/code-scanning/7](https://github.com/hyperpostulate/customer-api/security/code-scanning/7)

In general, the fix is to explicitly declare a `permissions` block in the workflow to limit the `GITHUB_TOKEN` to the minimum necessary scopes. For a simple Maven CI build that only checks out code and runs tests, `contents: read` is typically sufficient. This can be set at the workflow root (affecting all jobs) or at the job level; here, adding it at the workflow root is clean and does not change existing functionality, since none of the steps require write access.

The best fix here is to add a top-level `permissions:` section right after the `on:` block (or after the `name:` block and before `on:`; either is valid, but we’ll place it after `on:` to keep the diff small and focused on the area near the flagged job). Concretely, in `.github/workflows/maven.yml`, between the `on:` block (lines 11–15) and the `jobs:` block (line 17), insert:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or external dependencies are required; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
